### PR TITLE
add Fortran webinar newsletter post

### DIFF
--- a/_posts/2020-04-18-Fortran-Webinar.md
+++ b/_posts/2020-04-18-Fortran-Webinar.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Open Source Directions Fortran webinar
+category: newsletter
+---
+
+Ondřej Čertík ([@ondrejcertik](https://twitter.com/ondrejcertik)) and 
+Milan Curcic ([@realmilancurcic](https://twitter.com/realmilancurcic)) spoke 
+yesterday about the future of Fortran in Episode 40 of the Open Source 
+Directions Webinar.
+We discussed the current state of the language, how it's currently developed, 
+and what we can do today to build the Fortran community, ecosystem of packages, 
+and developer tools.
+
+Watch the episode now:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/2NiS2tdDO_4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+Special thanks to our hosts Melissa Mendonça 
+([@melissawm](https://twitter.com/melissawm)) and Madicken Munk 
+([@munkium](https://twitter.com/munkium)), as well as 
+[OpenTeams](https://openteams.com) and [QuanSight](https://www.quansight.com/)
+for having us.
+
+You can find all previous episodes of the Open Source Directions webinar 
+[here](https://www.quansight.com/open-source-directions).


### PR DESCRIPTION
This PR adds a newsletter post about the Open Source Directions Fortran webinar.

@certik please review, edit as needed, and merge.