### PR TITLE
Change date format to %d %b %Y in news list

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ title: Home
         {% for post in site.posts limit:posts_to_show %}
           <tr>
             <td><a href="{{ post.url }}">{{ post.title }}</a>&nbsp;&nbsp; </td>
-            <td style="white-space: nowrap; text-align: right">{{ post.date | date:"%B %Y" }}</td>
+            <td style="white-space: nowrap; text-align: right">{{ post.date | date:"%d %b %Y" }}</td>
           </tr>
           {% comment %} <dd></dd> {% endcomment %}
         {% endfor %}


### PR DESCRIPTION
Currently the date in the news list on the landing page is formatted as `%B %Y` (example: "February 2020").

For multiple news items in a single month, it's helpful to see a day value as well.

This PR changes the date format to `%d %b %Y` so that we have something like:

06 Apr 2020
25 Feb 2020