### PR TITLE
Add explore page for listing community projects.

### DIFF
--- a/_data/curated_projects.yml
+++ b/_data/curated_projects.yml
@@ -17,54 +17,412 @@
 #  'version'     (optional)
 #
 # Browsable category names (lowercase!):
-#   'numerical', 'libraries', 'programming', 'scientific'
+#   'numerical', 'libraries', 'scientific', 'examples', 'programming'
+#   'graphics', 'data-types', 'io', 'interfaces', 'strings'
 #
 # When adding a new library:
 #  - Check it shows up in the expected category page(s)
 #  - Temporarily use the category 'preview' and check 
 #     check the badges render correctly at /explore/category/preview
 #
+# No need to repeat keywords from 'description' in 'tags'
+#
+#
 
-# --- Libraries / Programming ---
+# --- General Libraries ---
 
 - name: functional-fortran
   github: wavebitscientific/functional-fortran
   description: Functional programming for modern Fortran
-  categories: libraries programming
+  categories: libraries
   tags: functional filter fold map
-
-- name: erloff
-  url: https://gitlab.com/everythingfunctional/erloff
-  description: Errors and logging for fortran
-  categories: libraries programming
-  tags: errors logging
-  license: "BSD 3-Clause"
-
-- name: json-fortran
-  github: jacobwilliams/json-fortran
-  description: A Fortran 2008 JSON API
-  categories: libraries programming
-  tags: json io
-  license: none
-
-- name: gtk-fortran
-  github: vmagnin/gtk-fortran
-  description: A cross-platform library to build Graphical User Interfaces (GUI)
-  categories: libraries programming
-  tags: gui gtk graphical user interface
 
 - name: fortran-utils
   github: certik/fortran-utils
   description: Various utilities for Fortran programs
-  categories: libraries programming
-  tags: constants types sorting io mesh spline ppm hdf5 lapack
+  categories: libraries io
+  tags: constants types sorting mesh spline ppm hdf5 lapack
   version: none
 
 - name: Open Coarrays
   github: sourceryinstitute/OpenCoarrays
   description: A parallel application binary interface for Fortran 2018 compilers.
-  categories: libraries programming
+  categories: libraries
   tags: mpi openshmem gfortran
+
+- name: FLAP
+  github: szaghi/FLAP
+  description: Fortran command Line Arguments Parser
+  categories: libraries
+  tags: command line cli argument parser
+  license: none
+
+- name: Fortran Standard Library (stdlib)
+  github: fortran-lang/stdlib
+  description: A community driven and agreed upon de facto standard library for Fortran
+  categories: libraries
+  version: none
+
+- name: coretran
+  github: leonfoks/coretran
+  description: Core fortran routines and object-oriented classes for sorting, kD-Trees, and other algorithms to handle scientific data and concepts
+  categories: libraries strings data-types programming
+  tags: dynamic array formatting debugging errors kdtree sorting random binary search strings unit testing timing
+
+- name: M_CLI
+  github: urbanjost/M_CLI
+  description: Unix-like command line argument parsing
+  categories: libraries
+  tags: namelist args
+  version: none
+
+- name: M_history
+  github: urbanjost/M_history
+  description: Subroutine to give a line-mode command history to interactive programs
+  categories: libraries
+  tags: redo
+  version: none
+
+# --- Interfaces ---
+
+- name: forpy
+  github: ylikx/forpy
+  description: allows you to use Python features in Fortran 
+  categories: interfaces
+  tags: dict list tuple numpy python matplotlib scipy
+  license: GNU GPL v3
+  version: none
+
+- name: tcp-client-server
+  github: modern-fortran/tcp-client-server
+  description: A minimal Fortran TCP client and server demonstrating c interoperability
+  categories: interfaces examples
+  tags: 
+  version: none
+
+- name: clfortran
+  github: cass-support/clfortran
+  description: Fortran interfaces to Khronos OpenCL 1.2 API
+  categories: interfaces
+  tags: gpu compute accelerator
+  version: none
+  license: GNU GPL v3
+
+- name: M_process
+  github: urbanjost/M_process
+  description: Read and write lines to or from a process from Fortran via a C wrapper
+  categories: interfaces
+  tags: 
+  version: none
+
+- name: M_system
+  github: urbanjost/M_system
+  description: Call C system routines from Fortran
+  categories: interfaces
+  tags: posix putenv getenv setenv environment file system mkdir rename rmdir chmod rand uname
+  version: none
+
+- name: Focal
+  github: LKedward/focal
+  description: A module library which wraps calls to the OpenCL runtime API with a higher abstraction level 
+  categories: interfaces
+  tags: gpu compute accelerator
+
+- name: foryxima
+  url: https://bitbucket.org/aradi/fortyxima/src/develop/
+  description: File system manipulation and unit testing framework
+  categories: interfaces programming
+  tags: posix libc
+  license: BSD 2-clause
+
+- name: sqliteff
+  url: https://gitlab.com/everythingfunctional/sqliteff
+  description: A thin wrapper around the SQLite library
+  categories: interfaces
+  tags: sql database
+  license: MIT
+
+
+# --- Programming utilities ---
+
+- name: FORD
+  github: Fortran-FOSS-Programmers/ford
+  description: Automatic documentation generator for modern Fortran programs
+  categories: programming preview
+  tags: documentation
+  
+
+- name: vegetables
+  url: https://gitlab.com/everythingfunctional/vegetables
+  description: A Fortran testing framework written using functional programming principles.
+  categories: programming 
+  tags: testing assert
+  license: MIT
+  version: 4.0
+
+- name: pFUnit
+  github: Goddard-Fortran-Ecosystem/pFUnit
+  description: Parallel Fortran Unit Testing Framework
+  categories: programming
+  tags: unit testing
+  license: none
+
+- name: erloff
+  url: https://gitlab.com/everythingfunctional/erloff
+  description: Errors and logging for fortran
+  categories: programming
+  tags: errors logging
+  license: "BSD 3-Clause"
+
+- name: fytest
+  url: https://bitbucket.org/aradi/fytest/src/develop/
+  description: a lightweight unit testing framework for Fortran
+  categories: programming
+  tags: unit testing
+  license: BSD 2-clause
+
+# --- Data types ---
+
+- name: Fortran template library
+  github: SCM-NV/ftl
+  description: Generic containers, versatile algorithms, easy string manipulation, and more
+  categories: data-types 
+  tags: resizeable array container linked list hash map regex string shared pointer
+  version: none
+  license: GNU GPL v3
+
+- name: PENF
+  github: szaghi/PENF
+  description: Provides portable kind-parameters and many useful procedures to deal with them
+  categories: data-types numerical
+  tags: kinds integer real ieee floating point floats precision
+  license: none
+
+- name: M_time
+  github: urbanjost/M_time
+  description: Procedures that expand on the Fortran DATE_AND_TIME intrinsic
+  categories: data-types
+  tags: date weekday unix epoch month convert moon phases duration
+  version: none
+
+- name: fdict
+  github: zerothi/fdict
+  description: Variable and type-free dictionary
+  categories: data-types
+  tags: hash table
+
+- name: kdtree2
+  github: jmhodges/kdtree2
+  description: A kd-tree implementation in fortran
+  categories: data-types
+  version: none
+  license: none
+
+- name: datetime-fortran
+  github: wavebitscientific/datetime-fortran
+  description: Date and time manipulation 
+  categories: data-types
+  tags: day year month calendar weekday clock
+  license: none
+  version: none
+
+- name: qContainers
+  github: darmar-lt/qcontainers
+  description: Store any intrinsic or derived data type to a container
+  categories: data-types
+  tags: qlibc tree table hash table linked list vector dynamic array unique set
+  license: none
+  version: none
+
+- name: Lookup Table Fortran
+  github: jannisteunissen/lookup_table_fortran
+  description: Linear lookup table implemented in modern Fortran
+  categories: data-types
+  tags: 
+  version: none
+
+- name: FyCollections
+  url: https://bitbucket.org/aradi/fycollections/src/develop/
+  description: generic collection templates for Fortran
+  categories: data-types
+  tags: 
+  license: BSD 2-Clause
+
+
+# --- Strings ---
+
+- name: StringiFor
+  github: szaghi/StringiFor
+  description: Fortran strings manipulator
+  categories: strings
+  tags: split join basename search concat
+  license: none
+
+- name: M_strings
+  github: urbanjost/M_strings
+  description: Fortran string manipulations
+  categories: strings
+  tags: upper lower quoted join replace white space string conversion tokens split 
+  version: none
+
+- name: Strings for Fortran
+  url: https://gitlab.com/everythingfunctional/strff
+  description: A library of string functions for Fortran.
+  categories: strings
+  tags: 
+  license: MIT
+
+- name: iso_varying_string
+  url: https://gitlab.com/everythingfunctional/iso_varying_string
+  description: Implementation of the Fortran ISO_VARYING_STRING module in accordance with the standard
+  categories: strings
+  tags: varying length character strings
+  license: MIT
+
+# --- File input / output ---
+
+- name: json-fortran
+  github: jacobwilliams/json-fortran
+  description: A Fortran 2008 JSON API
+  categories: io
+  tags: json io
+  license: none
+
+- name: VTKFortran
+  github: szaghi/VTKFortran
+  description: Library to parse and emit files conforming VTK (XML) standard
+  categories: io
+  tags: 
+  license: none
+  version: none
+
+- name: netCFD-Fortran
+  github: Unidata/netcdf-fortran
+  description: Fortran interfaces for netCFD C library.
+  categories: io
+  tags: netcdf
+  license: none
+
+- name: fox
+  github: andreww/fox
+  description: A Fortran XML library
+  categories: io
+  tags: 
+  license: none
+  version: none
+
+- name: FEconv
+  github: victorsndvg/FEconv
+  description: utility and library for converting between mesh and finite element field formats
+  categories: io
+  tags: ansys msh nastran bdf vtk 
+  version: none
+
+- name: h5fortran
+  github: scivision/h5fortran
+  description: Simple, robust, thin HDF5 polymorphic read/write interface
+  categories: io
+  tags: hdf5
+
+- name: nc4fortran
+  github: scivision/nc4fortran
+  description: Object-oriented interface for NetCDF4 in Fortran
+  categories: io
+  tags: netcdf
+
+- name: fortran-csv-module
+  github: jacobwilliams/fortran-csv-module
+  description: Read and write CSV Files using modern Fortran
+  categories: io
+  tags: 
+  license: none
+
+- name: M_IO
+  github: urbanjost/M_io
+  description: Fortran module for common I/O tasks
+  categories: io
+  tags: delete slurp swallow dirname split path 
+  license: Public domain
+  version: none
+
+- name: jsonff
+  url: https://gitlab.com/everythingfunctional/jsonff
+  description: Routines for building JSON structures in Fortran
+  categories: io
+  tags: 
+  license: MIT
+
+- name: NPY for Fortran
+  github: MRedies/NPY-for-Fortran
+  description: Allows saving numerical Fortran arrays in Numpy's .npy or .npz format
+  categories: io
+  tags: python
+
+- name: FiNeR
+  github: szaghi/FiNeR
+  description: INI ParseR and generator
+  categories: io 
+  tags: config
+  license: none
+
+- name: config_fortran
+  github: jannisteunissen/config_fortran
+  description: Configuration file parser for Fortran
+  categories: io
+  tags: 
+  version: none
+
+- name: Parser for Fortran
+  url: https://gitlab.com/everythingfunctional/parff
+  description: The foundations of a functional style parser combinator library
+  categories: io
+  tags: 
+  license: MIT
+
+
+# --- Graphics ---
+
+- name: pyplot-fortran
+  github: jacobwilliams/pyplot-fortran
+  description: For generating plots from Fortran using Python's matplotlib.pyplot
+  categories: graphics interfaces
+  tags: pyplot matplotlib contour histogram
+  license: none
+
+- name: ogpf
+  github: kookma/ogpf
+  description: Object based interface to GnuPlot for Fortran
+  categories: graphics interfaces
+  tags: animation plot surface contour 
+  license: none
+  version: none
+
+- name: gtk-fortran
+  github: vmagnin/gtk-fortran
+  description: A cross-platform library to build Graphical User Interfaces (GUI)
+  categories: graphics interfaces
+  tags: gui gtk graphical user interface
+
+- name: M_draw
+  github: urbanjost/M_draw
+  description: Low-level vector graphics library
+  categories: graphics
+  tags: 
+  version: none
+
+- name: fortran-xlib
+  github: interkosmos/fortran-xlib
+  description: A collection of ISO C binding interfaces to Xlib for Fortran 2003
+  categories: graphics interfaces
+  tags: x11 mandelbrot raycast wireframe
+  version: none
+
+- name: fortran-sdl2
+  github: interkosmos/fortran-sdl2
+  description: A collection of ISO C binding interfaces to Simple DirectMedia Layer 2.0 (SDL 2.0), for multimedia and game programming in Fortran
+  categories: graphics interfaces
+  tags: 
+  version: none
 
 # --- Numerical libraries ---
 
@@ -90,22 +448,105 @@
 - name: fortranlib
   github: astrofrog/fortranlib
   description: Collection of personal scientific routines in Fortran
-  categories: libraries numerical io
+  categories: libraries numerical io interfaces
   tags: solver integral integrate interpolation histogram constants hdf5 error random posix angles probability stokes vectors
   version: none
 
 - name: SHTOOLS
   github: SHTOOLS/SHTOOLS
   description: A Fortran-95/Python library that can be used to perform spherical harmonic transforms
-  categories: libraries numerical
+  categories: numerical
   tags: spectral analysis Slepian bases gravitational magnetic field openmp
 
 - name: ARPACK
   github: opencollab/arpack-ng
   description: Collection of Fortran77 subroutines designed to solve large scale eigenvalue problems.
-  categories: libraries numerical
+  categories: numerical
   tags: eigenvalue eigenvector singular value decomposition svd
   license: none
+  version: none
+
+- name: neural-fortran
+  github: modern-fortran/neural-fortran
+  description: A parallel neural net microframework.
+  categories: numerical
+  tags: back propagation coarray
+  version: none
+
+- name: bspline-fortran
+  github: jacobwilliams/bspline-fortran
+  description: Multidimensional B-Spline interpolation of data on a regular grid
+  categories: numerical
+  tags: spline interpolation extrapolation integration integral
+  license: none
+
+- name: FOODIE
+  github: Fortran-FOSS-Programmers/FOODIE
+  description: Fortran Object-Oriented Differential-equations Integration Environment
+  categories: numerical
+  tags: ode pde euler runge kutta
+  license: none
+
+- name: fgsl
+  github: reinh-bader/fgsl
+  description: Fortran interface to the GNU Scientific Library 
+  categories: numerical scientific
+  tags: 
+
+- name: SciFortran
+  github: aamaricci/SciFortran
+  description: collection of fortran modules and procedures for scientific calculations.
+  categories: numerical scientific
+  tags: 
+  version: none
+
+- name: Los Alamos Grid Toolbox (LaGriT)
+  github: lanl/LaGriT
+  description: a library of user callable tools that provide mesh generation, mesh optimization and dynamic mesh maintenance
+  categories: numerical
+  tags: 
+  license: BSD
+
+- name: DBCSR
+  github: cp2k/dbcsr
+  description: Distributed block compresseed sparse row matrix library
+  categories: numerical
+  tags: linear algebra parallel mpi openmp cuda hip
+
+- name: GALAHAD
+  github: ralna/GALAHAD
+  description: Modules for nonlinear optimization
+  categories: numerical
+  tags: least squares active set quadratic programming interior point convex programming linear programming
+  license: GNU LGPL v3
+
+- name: slsqp
+  github: jacobwilliams/slsqp
+  description: SLSQP nonlinear constrained optimizer
+  categories: numerical
+  tags: nonlinear programming equality inequality constraints 
+  license: none
+
+- name: NumDiff
+  github: jacobwilliams/NumDiff
+  description: a modern Fortran interface for computing the Jacobian (derivative) matrix of m nonlinear functions which depend on n variables
+  categories: numerical
+  tags: finite difference
+  license: none
+
+- name: quaff
+  url: https://gitlab.com/everythingfunctional/quaff
+  description: Quantities for Fortran. Make math with units more convenient
+  categories: numerical
+  tags: 
+  license: MIT
+
+- name: rng_fortran
+  github: jannisteunissen/rng_fortran
+  description: Pseudo random number generator in Fortran, internally using xoroshiro128+
+  categories: numerical
+  tags: uniform normal poisson distributed
+  license: GNU GPL v3
   version: none
 
 # --- Scientific codes ---
@@ -160,6 +601,22 @@
   license: none
   version: none
 
+- name: "OFF"
+  github: szaghi/OFF
+  description: Finite volume fluid dynamics
+  categories: scientific
+  tags: godunov riemann euler runge kutta structured
+  license: GNU GPL v3
+  version: none
+
+- name: freeCappuccino
+  github: nikola-m/freeCappuccino
+  description: A three-dimensional unstructured finite volume code for fluid flow simulations.
+  categories: scientific
+  tags: finite volume turbulent turbulence
+  license: GNU GPL v3
+  version: none
+
 
 # --- Examples / demos / templates ---
 
@@ -169,4 +626,17 @@
   categories: examples
   tags: block coarray contiguous mpi namelist openmp random submodule iso_fortran_env
   license: GNU GPL V2
+
+- name: Fortran patterns
+  github: farhanjk/FortranPatterns
+  description: Popular design patterns implemented in Fortran
+  categories: examples
+  tags:
+  version: none
   
+- name: Numerical methods in fortran
+  github: planelles20/numerical-methods-fortran
+  description: Solving linear, nonlinear equations, ordinary differential equations
+  categories: examples numerical
+  tags: ode pde integral stochastic quadrature plotting
+  version: none

--- a/_data/curated_projects.yml
+++ b/_data/curated_projects.yml
@@ -1,0 +1,172 @@
+# Fields for github projects:
+#  'name'        (mandatory)
+#  'github'      (mandatory) format: <user>/<repo>
+#  'description' (mandatory) single line description
+#  'categories'  (mandatory)
+#  'tags'        (optional) used for searching. Don't include category name here.
+#  'license'     (optional) override automatic github license. Set to 'none' to hide.
+#  'version'     (optional) override automatic github version. Set to 'none' to hide.
+#
+# Fields for non github projects:
+#  'name'        (mandatory)
+#  'url'         (mandatory)
+#  'description' (mandatory) single line description
+#  'categories'  (mandatory)
+#  'tags'        (optional) used for searching. Don't include category name here.
+#  'license'     (optional)
+#  'version'     (optional)
+#
+# Browsable category names (lowercase!):
+#   'numerical', 'libraries', 'programming', 'scientific'
+#
+# When adding a new library:
+#  - Check it shows up in the expected category page(s)
+#  - Temporarily use the category 'preview' and check 
+#     check the badges render correctly at /explore/category/preview
+#
+
+# --- Libraries / Programming ---
+
+- name: functional-fortran
+  github: wavebitscientific/functional-fortran
+  description: Functional programming for modern Fortran
+  categories: libraries programming
+  tags: functional filter fold map
+
+- name: erloff
+  url: https://gitlab.com/everythingfunctional/erloff
+  description: Errors and logging for fortran
+  categories: libraries programming
+  tags: errors logging
+  license: "BSD 3-Clause"
+
+- name: json-fortran
+  github: jacobwilliams/json-fortran
+  description: A Fortran 2008 JSON API
+  categories: libraries programming
+  tags: json io
+  license: none
+
+- name: gtk-fortran
+  github: vmagnin/gtk-fortran
+  description: A cross-platform library to build Graphical User Interfaces (GUI)
+  categories: libraries programming
+  tags: gui gtk graphical user interface
+
+- name: fortran-utils
+  github: certik/fortran-utils
+  description: Various utilities for Fortran programs
+  categories: libraries programming
+  tags: constants types sorting io mesh spline ppm hdf5 lapack
+  version: none
+
+- name: Open Coarrays
+  github: sourceryinstitute/OpenCoarrays
+  description: A parallel application binary interface for Fortran 2018 compilers.
+  categories: libraries programming
+  tags: mpi openshmem gfortran
+
+# --- Numerical libraries ---
+
+- name: OpenBLAS
+  github: xianyi/OpenBLAS
+  description: Optimized BLAS library based on GotoBLAS2
+  categories: numerical
+  tags: blas linear algebra
+
+- name: LAPACK
+  github: xianyi/OpenBLAS
+  description: Routines for numerical linear algebra
+  categories: numerical
+  tags: blas linear algera
+
+- name: ElmerFEM
+  github: ElmerCSC/elmerfem
+  description: Finite element software for numerical solution of partial differential equations
+  categories: numerical
+  tags: pde fe
+  version: none
+
+- name: fortranlib
+  github: astrofrog/fortranlib
+  description: Collection of personal scientific routines in Fortran
+  categories: libraries numerical io
+  tags: solver integral integrate interpolation histogram constants hdf5 error random posix angles probability stokes vectors
+  version: none
+
+- name: SHTOOLS
+  github: SHTOOLS/SHTOOLS
+  description: A Fortran-95/Python library that can be used to perform spherical harmonic transforms
+  categories: libraries numerical
+  tags: spectral analysis Slepian bases gravitational magnetic field openmp
+
+- name: ARPACK
+  github: opencollab/arpack-ng
+  description: Collection of Fortran77 subroutines designed to solve large scale eigenvalue problems.
+  categories: libraries numerical
+  tags: eigenvalue eigenvector singular value decomposition svd
+  license: none
+  version: none
+
+# --- Scientific codes ---
+
+- name: WRF
+  github: wrf-model/WRF
+  description: Weather Research and Forecasting model
+  categories: scientific
+  license: Public domain
+
+- name: fds
+  github: firemodels/fds
+  description: Large-eddy simulation code for low-speed flows, with an emphasis on smoke and heat transport from fires.
+  categories: scientific
+  license: none
+
+- name: QEF
+  github: QEF/q-e
+  description: Codes for electronic-structure calculations and materials modeling at the nanoscale.
+  categories: scientific
+  tags: electron structure simulation physics
+
+- name: fluidity
+  github: FluidityProject/fluidity
+  description: Computational fluid dynamics code with adaptive unstructured mesh capabilities
+  categories: scientific
+  tags: cfd computational fluid dynamics unstructured
+
+- name: fortran-machine
+  github: mapmeld/fortran-machine
+  categories: other
+
+- name: Nek5000
+  github: Nek5000/Nek5000
+  description: MPI parallel higher-order spectral element CFD solver
+  categories: scientific
+  tags: cfd computational fluid dynamics spectral element higher order mpi parallel les rans
+  license: none
+
+- name: cp2k
+  github: cp2k/cp2k
+  description: quantum chemistry and solid state physics software package that can perform atomistic simulations 
+  categories: scientific
+  tags: quantum chemistry physics molecular dynamics metadynamics mpi cuda
+  license: GNU GPL V2
+
+- name: NASTRAN 95
+  github: nasa/NASTRAN-95
+  description: NASA Structural Analysis System, a finite element analysis program (FEA) completed in the early 1970's 
+  categories: scientific
+  tags: finite element structural eigne stability loads
+  license: none
+  version: none
+
+
+# --- Examples / demos / templates ---
+
+- name: Fortran 2018 examples
+  github: scivision/fortran2018-examples
+  description: Easy examples of scientific computing with modern, powerful, easy Fortran 2018 standard
+  categories: examples
+  tags: block coarray contiguous mpi namelist openmp random submodule iso_fortran_env
+  license: GNU GPL V2
+  

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -2,14 +2,7 @@
   url: /learn/
 - title: Compilers
   url: /compilers/
-- title: Development
-  url: https://github.com/fortran-lang
-  sections:
-    - title: Proposals
-      url: https://github.com/j3-fortran/fortran_proposals
-    - title: Standard Library
-      url: https://github.com/fortran-lang/stdlib
-    - title: Package Manager
-      url: https://github.com/fortran-lang/fpm
+- title: Explore
+  url: /explore
 - title: News
   url: /news/

--- a/_layouts/code_category.html
+++ b/_layouts/code_category.html
@@ -1,0 +1,90 @@
+---
+layout: default
+---
+
+{% include nav.html %}
+
+<section class="masthead">
+    <h1>Explore Community Fortran Projects</h1>
+    <h3>A rich ecosystem of high-performance code</h3>
+  </section>
+  
+  <section class="front-section">
+    <div class="container">
+      <div class="col-wide">
+          
+          <a href='/explore'> < Back</a>
+
+          <h1>{{page.title}}</h1>
+          <p>
+              {{page.description}}
+          </p>
+  
+          <table class="projects-table">
+         
+          {% assign catProjects =  site.data.curated_projects | where_exp:"project", "project.categories contains page.code_category"%}
+          {% for project in catProjects %}
+          <tr>
+              {% if project.github %}
+              <td> <h4><a href="https://github.com/{{ project.github }}">{{ project.name }}</a></h4> </td>
+              <td> {% if project.version %}
+                  {% if project.version != 'none' %}
+                  <img src="https://img.shields.io/badge/Version-{{ project.version | replace: " ", "%20" | replace: "-", "--" }}-green.svg">
+                  {% endif%}
+                  {% else %}
+                  <img src="https://img.shields.io/github/v/release/{{ project.github }}?color=green">
+              {% endif %}</td>
+              <td> {% if project.license %}
+                   {% if project.license != 'none' %}
+                   <img src="https://img.shields.io/badge/License-{{ project.license | replace: " ", "%20" | replace: "-", "--" }}-green">
+                   {% endif%}
+                   {% else %}
+                   <img src="https://img.shields.io/github/license/{{ project.github }}">
+               {% endif %}</td>
+              <td> <img src="https://img.shields.io/github/stars/{{ project.github }}?style=social"></td>
+              <td> <img src="https://img.shields.io/github/forks/{{ project.github }}?style=social&label=Fork"> </td>
+              <td> <img src="https://img.shields.io/github/last-commit/{{ project.github }}?color=blue"> </td>
+              <td> <img src="https://img.shields.io/github/issues/{{ project.github }}"> </td>
+              {% else %}
+              <td> <h4><a href="{{ project.url }}">{{ project.name }}</a></h4> </td>
+              <td> {% if project.version %}
+                  <img src="https://img.shields.io/badge/Version-{{ project.version | replace: " ", "%20" | replace: "-", "--" }}-green.svg">
+                  {% endif %}
+              </td>
+              <td> {% if project.license %}
+                  <img src="https://img.shields.io/badge/License-{{ project.license | replace: " ", "%20" | replace: "-", "--" }}-green">
+                  {% endif %}
+              </td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              {% endif %}
+          </tr>
+          <tr><td colspan="7" class="light">
+              {{ project.description }}
+          </td></tr>
+          <tr><td colspan="7" class="light small">
+            <b>Tags: </b>{{ project.tags }}
+        </td></tr>
+          <tr><td colspan="7"></td></tr>
+          {% endfor %} 
+          
+          </table>        
+         
+      </div>
+  
+    </div>
+  </section>
+  
+  <section class="front-section shaded">
+    <div class="container">
+      <div class="col-wide">
+        <!-- <h2 id="faqs">FAQ</h2> -->
+        
+        Want your project listed or see a problem? Submit an issue
+        <a href="https://github.com/fortran-lang/fortran-lang.github.io/issues">here</a>.
+  
+    </div>
+  </section>
+  

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -49,6 +49,12 @@ h3 {
   /* color: #54a23d; */
 }
 
+/* Mark new-window links */
+a[target="_blank"]:after {
+  content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+  margin: 0 3px 0 5px;
+}
+
 blockquote {
   border-left: 5px solid #eeeeee;
   margin-left: 0;
@@ -82,6 +88,26 @@ pre {
     margin: 0 auto;
     width: 90%;
     max-width: 1200px;
+  }
+}
+
+.container-flex{
+  margin: 0 15px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.col-flex {
+  /* display: table-cell; */
+  flex: 45%;
+  padding-left: 10px;
+  vertical-align: top;
+}
+
+@media screen and (max-width: 700px) {
+  .col-flex {
+    flex: 100%;
+    flex-direction: column; 
   }
 }
 
@@ -231,6 +257,30 @@ pre {
   width: 100%;
 }
 
+.search-btn {
+  display: inline-block;
+  text-align: center;
+  vertical-align: middle;
+  background-color: #3c92d1;
+  color: #fff;
+  font-family: 'Lato', sans-serif;
+  border-radius: 4px;
+  padding: 5px 7px;
+}
+
+.search-btn:hover {
+  background-color: #3889c4;
+  color: white;
+}
+
+.search-box {
+  width: 85%;
+  padding: 5px 7px;
+  color: #777;
+  font-weight: bold;
+}
+
+
 footer .container {
   border-top: solid 1px #ececec;
   padding: 20px 0 50px;
@@ -292,4 +342,10 @@ footer a {
   padding-left: 10px;
   margin: 20px 0;
   background-color: #f9f2f4;
+}
+
+.projects-table td{
+
+  padding: 4px;
+
 }

--- a/explore/category/data-types.html
+++ b/explore/category/data-types.html
@@ -1,0 +1,7 @@
+---
+layout: code_category
+title: Data types and containers
+description: Libraries for advanced data types and container classes
+code_category: data-types
+---
+

--- a/explore/category/examples.html
+++ b/explore/category/examples.html
@@ -1,0 +1,8 @@
+---
+layout: code_category
+title: Examples and templates
+description: Demonstration codes and templates for Fortran
+code_category: examples
+permalink: /explore/category/examples
+---
+

--- a/explore/category/graphics.html
+++ b/explore/category/graphics.html
@@ -1,0 +1,7 @@
+---
+layout: code_category
+title: Graphics, plotting and user interfaces
+description: Libraries for plotting data, handling images and generating user interfaces
+code_category: graphics
+---
+

--- a/explore/category/interfaces.html
+++ b/explore/category/interfaces.html
@@ -1,0 +1,7 @@
+---
+layout: code_category
+title: Interface libraries
+description: Libraries that interface with other systems languages, or devices
+code_category: interfaces
+---
+

--- a/explore/category/io.html
+++ b/explore/category/io.html
@@ -1,0 +1,7 @@
+---
+layout: code_category
+title: File input & output
+description: Libraries for reading and writing particular file formats
+code_category: io
+---
+

--- a/explore/category/libraries.html
+++ b/explore/category/libraries.html
@@ -1,0 +1,7 @@
+---
+layout: code_category
+title: Libraries
+description: Fortran libraries for general programming tasks
+code_category: libraries
+---
+

--- a/explore/category/numerical.html
+++ b/explore/category/numerical.html
@@ -1,0 +1,7 @@
+---
+layout: code_category
+title: Numerical projects
+description: Fortran libraries for linear algebra, optimization, root-finding etc.
+code_category: numerical
+---
+

--- a/explore/category/preview.html
+++ b/explore/category/preview.html
@@ -1,0 +1,8 @@
+---
+layout: code_category
+title: Preview
+description: Preview project badges
+code_category: preview
+permalink: /explore/category/preview
+---
+

--- a/explore/category/programming.html
+++ b/explore/category/programming.html
@@ -1,0 +1,7 @@
+---
+layout: code_category
+title: Programming utilities
+description: Error handling, logging, documentation and testing
+code_category: programming
+---
+

--- a/explore/category/scientific.html
+++ b/explore/category/scientific.html
@@ -1,0 +1,8 @@
+---
+layout: code_category
+title: Scientific Codes
+description: Fortran libraries for applied mathematical and scientific problems
+code_category: scientific
+permalink: /explore/category/scientific
+---
+

--- a/explore/category/strings.html
+++ b/explore/category/strings.html
@@ -1,0 +1,7 @@
+---
+layout: code_category
+title: Characters and strings
+description: Libraries for manipulating characters and strings
+code_category: strings
+---
+

--- a/explore/index.html
+++ b/explore/index.html
@@ -1,0 +1,91 @@
+---
+layout: default
+title: Explore Fortran Code
+description: 
+---
+
+{% include nav.html active='Home' %}
+
+<section class="masthead">
+  <h1>{{ page.title}}</h1>
+  <h3>A rich ecosystem of high-performance code</h3>
+</section>
+
+<section class="front-section shaded">
+    <div class="container">
+      <h2>Fortran-lang organisation projects</h2>
+  
+      <div class="col-narrow">
+        <h3>Fortran Standard Library (stdlib)</h3>
+        <p>
+        A community-driven project for a <i>de facto</i> "standard" library for Fortran.
+        The stdlib project is both a specification and a reference implementation, developed in
+        cooperation with the Fortran Standards Committee.
+        Find out more on
+        <a href="https://github.com/fortran-lang/stdlib" target="_blank">GitHub</a>.
+        </p>
+        <img src="https://img.shields.io/github/stars/fortran-lang/stdlib?style=social">
+        <img src="https://img.shields.io/github/forks/fortran-lang/stdlib?style=social&label=Fork"> 
+        <img src="https://img.shields.io/github/last-commit/fortran-lang/stdlib?color=blue">
+        <img src="https://img.shields.io/github/issues/fortran-lang/stdlib">
+        
+      </div>
+  
+      <div class="col-narrow">
+        <h3>Fortran Package Manager (fpm)</h3>
+        <p>
+        A prototype project to develop a common build system for Fortran packages
+        and their dependencies.
+        Find out more on
+        <a href="https://github.com/fortran-lang/fpm" target="_blank">GitHub</a>.
+        </p>
+        <img src="https://img.shields.io/github/stars/fortran-lang/fpm?style=social">
+        <img src="https://img.shields.io/github/forks/fortran-lang/fpm?style=social&label=Fork"> 
+        <img src="https://img.shields.io/github/last-commit/fortran-lang/fpm?color=blue">
+        <img src="https://img.shields.io/github/issues/fortran-lang/fpm">
+      </div>
+  
+    </div>
+  </section>
+
+<section class="front-section">
+  <div class="container">
+  <h1>Featured community projects</h1>
+
+  <form action="/explore/search" method="get">
+    <input type="text" name="query" class="search-box" placeholder="Search for a project">
+    <input type="submit" value="Search" class="search-btn">
+  </form>
+
+  <h2>Browse by category</h2>
+  <div class="container-flex">
+
+      {% for sitePage in site.pages %}
+
+      {% if sitePage.code_category %}
+      {% if sitePage.code_category != 'preview' %}
+      <div class="col-flex">
+          <a href="{{ sitePage.url }}" ><h3>{{ sitePage.title }}
+            {% assign catProjects =  site.data.curated_projects | where_exp:"project", "project.categories contains sitePage.code_category"%}
+            ({{ catProjects | size }})
+          </h3></a>
+          <p> {{ sitePage.description }} </p>
+        </div>
+      {% endif %}
+      {% endif %}
+
+      {% endfor%}
+    </div>
+    </div>
+</section>
+
+<section class="front-section shaded">
+  <div class="container">
+    <div class="col-wide">
+      
+      Want your project listed or see a problem? Submit an issue
+        <a href="https://github.com/fortran-lang/fortran-lang.github.io/issues">here</a>.
+
+  </div>
+</section>
+

--- a/explore/projects_json.js
+++ b/explore/projects_json.js
@@ -1,0 +1,17 @@
+---
+layout: null
+---
+
+projects = [
+      {% for project in site.data.curated_projects%}
+        {
+          "name": "{{ project.name }}",
+          "description": "{{ project.description }}",
+          "github": "{{ project.github }}",
+          "url": "{{ project.url }}",
+          "categories": "{{ project.categories }}",
+          "tags": "{{ project.tags }}",
+          "license": "{{ project.license }}"
+        },
+      {% endfor %}
+    ]

--- a/explore/projects_search.js
+++ b/explore/projects_search.js
@@ -1,0 +1,145 @@
+function findGetParameter(parameterName) {
+    // Return a GET HTTP parameter
+    var result = null,
+        tmp = [];
+    location.search
+        .substr(1)
+        .split("&")
+        .forEach(function (item) {
+          tmp = item.split("=");
+          if (tmp[0] === parameterName) result = decodeURIComponent(tmp[1]);
+        });
+    return result;
+}
+
+function getSubSentences(sentence) {
+    // Return all permutations of contiguous sub sentences from a sentence
+    var words = sentence.split(" ");
+
+    var subs = [];
+
+    var N = words.length;
+
+    var i;
+    for (i = 1; i <= N; i++){ // Loop over possible sentence lengths
+
+        var j;
+        for (j=0; j<=(N-i); j++){ // Loop over sentence locations
+
+            sub_i = words.slice(j,j+i);
+            subs.push(sub_i.join(" "));
+
+        }
+
+    }
+
+    return subs;
+
+}
+
+function searchProjects(queryString,projects) {
+    // Basic sub-string matching within project fields
+    //
+    //  Results ranked by size of matched sub-string and field weight
+    //
+    var subs = getSubSentences(queryString);
+
+    // Sort by subsentence length descending
+    subs = subs.sort(function(a,b){return b.split(" ").length - a.split(" ").length})
+
+    var fields = ['name','description','tags','license','github','url'];
+    var fieldWeights = [10.0,1.0,1.0,0.1,1.0,0.1];
+
+    // Loop over projects JSON
+    var i;
+    for (i = 0; i<projects.length; i++){
+
+        var j;
+
+        projects[i].score = 0;
+
+        var subMatch = [];
+        for (j=0; j<subs.length; j++){
+            subMatch[j] = false;
+        }        
+
+        for (j=0; j<fields.length; j++){
+
+            var k;
+            for (k=0; k<subs.length; k++){
+
+                if (subMatch[k]){
+                    // Don't match a sub-sentence more than once per project
+                    continue;
+                }
+
+                fieldData = projects[i][fields[j]].toLowerCase();
+                querySubString = subs[k].toLowerCase();
+                queryStringLength = querySubString.split(" ").length;
+
+                if (fieldData.includes(querySubString)){
+
+                    subMatch[k] = true;
+                    projects[i].score += fieldWeights[j]*queryStringLength;
+                    break;
+
+                }
+
+            }
+
+        }
+
+    }
+
+    return projects.sort(function(a,b){return b.score - a.score});
+
+}
+
+function resultsToHTML(results){
+    // Return HTML representation of search results
+    //
+
+    var out = "";
+    var i;
+    for (i=0;i<results.length;i++){
+    
+        if (results[i].score > 0){
+    
+            project = results[i];
+    
+            if (results[i].github != ""){
+                out += '<b><a href="https://github.com/'+project.github+'" target="_blank">'+project.name+'</a></b>';
+            } else{
+                out += '<b><a href="'+project.url+'" target="_blank">'+project.name+'</a></b>';
+            }
+    
+            var cats = project.categories.split(" ");
+            out += ' ('
+            var j;
+            for (j=0;j<cats.length;j++){
+                out += '<a href="/explore/category/'+cats[j]+'">'+cats[j]+'</a>';
+                if (j<cats.length-1){
+                    out += ', ';
+                }
+            }
+            out += ')'
+    
+            out += '<p>'+project.description+'</p>';
+    
+            out += '<p class="light small"><b>Tags: </b>'+project.tags+'</p></br>';
+    
+        }
+    
+    }
+    
+    return out;
+
+}
+
+// Perform search here onload
+var queryString = findGetParameter('query').replace(/\+/g," ").replace(/"/g,'');
+document.getElementById('search-query').value = queryString;
+
+results = searchProjects(queryString,projects);
+resultsHTML = resultsToHTML(results);
+document.getElementById('search-results').innerHTML = resultsHTML;

--- a/explore/search.html
+++ b/explore/search.html
@@ -1,0 +1,42 @@
+---
+layout: default
+---
+
+{% include nav.html %}
+  
+<script src="/explore/projects_json.js"></script>
+
+
+  <section class="front-section">
+    <div class="container">
+      <div class="col-wide">
+          
+          <a href='/explore'> < Back</a>
+
+          <h1>Search community projects</h1>
+          
+          <form action="/explore/search" method="get">
+            <input type="text" name="query" id="search-query" class="search-box" placeholder="Search for a project">
+            <input type="submit" value="Search" class="search-btn">
+          </form>
+        </br>
+
+        <div id="search-results"></div>
+
+      </div>
+  
+    </div>
+  </section>
+  
+  <section class="front-section shaded">
+    <div class="container">
+      <div class="col-wide">
+        <!-- <h2 id="faqs">FAQ</h2> -->
+        
+        Want your project listed or see a problem? Submit an issue
+        <a href="https://github.com/fortran-lang/fortran-lang.github.io/issues">here</a>.
+  
+    </div>
+  </section>
+  
+  <script src="/explore/projects_search.js"></script>


### PR DESCRIPTION
Inspired by your [comment](https://github.com/fortran-lang/stdlib/issues/110#issue-551592218) @certik, I've put together a very simple and (hopefully) user-friendly community project index page.

The 'Development' top-level page has been replaced with an 'Explore' page which lists foremost the _stdlib_ and _fpm_ projects followed by a searchable index of community code packages also broken down by category.

Packages are listed centrally by metadata in a yaml file, everything else is generated.
I've populated a few popular packages to start off with.
Eventually this could involve some integration with FPM.

Search functionality is fairly rudimentary based on substrings.

I've included automated badges for github stars _etc._ as done [here](https://maulingmonkey.com/guide/cpp-vs-rust/#crates-of-note), though do note they take some time to load due to the API - there might be a way to cache them, but I can't think how exactly.

Feedback welcome.

__Preview this pull request statically [here](https://lkedward.github.io/fortran-lang.github.io/pr/explore-code/)__