### PR TITLE
Reorder open source compilers

### DIFF
--- a/compilers.md
+++ b/compilers.md
@@ -16,10 +16,6 @@ free and open source compiler, part of the GNU Compiler Collection.
 around gfortran which enables the parallel programming features of Fortran 2018
 with gfortran.
 
-### LFortran
-
-[LFortran](https://lfortran.org) is a modern, interactive, LLVM-based Fortran
-compiler.
 
 ### LLVM Flang
 
@@ -34,6 +30,12 @@ This project is under active development.
 
 [Flang](https://github.com/flang-compiler/flang) is an open source compiler 
 based on the NVIDIA/PGI commercial compiler.
+
+
+### LFortran
+
+[LFortran](https://lfortran.org) is a modern, interactive, LLVM-based Fortran
+compiler.
 
 
 ## Commercial compilers


### PR DESCRIPTION
I think the order now roughly reflects the maturity, community size and
mind-share in that order.

As the author of LFortran, I approve this change.