### PR TITLE
Update: news page to show more posts

### DIFF
--- a/news/archive.html
+++ b/news/archive.html
@@ -9,11 +9,18 @@ title: News archive
   <div class="container">
     <div class="newsletter col-wide">
 
-      <h1>{{ page.title }}</h1>
+      <h1><a href="/news">News</a> / Archive</h1>
 
-{% for post in site.categories.newsletter reversed %}
-      <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
-{% endfor %}
+      {% assign postsByYearMonth = site.categories.newsletter | group_by_exp:"post", "post.date | date: '%B %Y'"  %}
+      {% for yearMonth in postsByYearMonth %}
+        <h3>{{ yearMonth.name }}</h3>
+          <ul>
+            {% for post in yearMonth.items %}
+              <li><a href="{{ post.url }}">{{ post.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+      {% endfor %}
 
     </div>
 

--- a/news/index.html
+++ b/news/index.html
@@ -3,23 +3,47 @@ layout: default
 title: News
 ---
 
-{% include nav.html %}
+{% include nav.html active="News" %}
 
 <section class="front-section">
   <div class="container">
     <div class="newsletter col-wide">
 
-      <h1>{{ site.categories.newsletter.first.title }}</h1>
+      {% for post in site.categories.newsletter limit:5 %}
 
-      <div style="margin-top: 0.5em; margin-bottom: 0.5em;">
-        <a class="release-date" href="{{ site.categories.newsletter.first.url }}"
-          >{{ site.categories.newsletter.first.date | date: "%B %Y" }}</a>
-      </div>
+        <h1>{{ post.title }}</h1>
 
-      {{ site.categories.newsletter.first.content }}
+        <div style="margin-top: 0.5em; margin-bottom: 0.5em;">
+          <p><b>{{ post.date | date: "%d %B %Y" }}</b></p>
+            {% if post.author %}
+              <p><b>Authors:</b> {{ post.author }}</p>
+            {% endif %}
+        </div>
+        
+        {% if post.title == site.categories.newsletter.first.title %}
+          {{ post.content }}
+        {% else %}
+          {{ post.excerpt }}
+          <a class="release-date" href="{{ post.url }}">
+            Read more > </a>
+        {% endif %}
+      </br>
+
+      {% endfor %}
 
     </div>
 
     {% include news_sidebar.html %}
   </div>
+</section>
+
+  <section class="front-section shaded">
+    <div class="container">
+      <div class="col-wide">
+        
+        See the 
+          <a href="/news/archive">news archive</a> for older posts  
+      </div>
+    </div>
+
 </section>


### PR DESCRIPTION
Fixes #35.
News page shows last five posts; first post is shown in full.
Archive page formatting updated to group posts.
Nav bar highlighting fixed for news pages.