### PR TITLE
Fix: navbar highlighting and sign-posting

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% include nav.html %}
+{% include nav.html active=page.navbar %}
 
 <section class="front-section">
   <div class="container">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,19 +2,22 @@
 layout: default
 ---
 
-{% include nav.html %}
+{% include nav.html active="News" %}
 
 <section class="front-section">
   <div class="container">
     <div class="newsletter col-wide">
 
+      <a href="/news" > < Back to news</a>
+
       <h1>{{ page.title }}</h1>
 
       <div style="margin-top: 0.5em; margin-bottom: 0.5em;">
-        <i>{{ page.date | date: "%B %d, %Y" }}</i>
+        <p><i>{{ page.date | date: "%B %d, %Y" }}</i></p>
+        {% if page.author != null %}
+          <p><b>Authors:</b> {{ page.author }}</p>
+        {% endif %}
       </div>
-
-      <h2>{{ page.author }}</h2>
 
       {{ content }}
 

--- a/_posts/2020-02-28-J3-february-meeting.md
+++ b/_posts/2020-02-28-J3-february-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: post
 title: J3 February 2020 Meeting
 category: newsletter
 author: Ondřej Čertík and Zach Jibben

--- a/_posts/2020-04-06-Announcing-FortranCon-2020.md
+++ b/_posts/2020-04-06-Announcing-FortranCon-2020.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: post
 title: Announcing FortranCon 2020
 category: newsletter
 ---

--- a/_posts/2020-04-18-Fortran-Webinar.md
+++ b/_posts/2020-04-18-Fortran-Webinar.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: post
 title: Open Source Directions Fortran webinar
 category: newsletter
 ---

--- a/compilers.md
+++ b/compilers.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Fortran Compilers
+navbar: Compilers
 ---
 
 Fortran has several open source and commercial compilers.

--- a/learn/index.md
+++ b/learn/index.md
@@ -2,6 +2,7 @@
 layout: page
 title: Quickstart Fortran
 permalink: /learn/
+navbar: Learn
 ---
 
 This quickstart tutorial assumes familiarity with basic programming concepts such as types, variables, arrays, control flow and functions.


### PR DESCRIPTION
Fixes #39
Compilers and Learn section are now highlighting correctly.
The newsletters have been switched to using the 'post' layout so that 'News' is highlighted in the navbar.