### PR TITLE
Update: packages footer with instructions link.

### DIFF
--- a/_layouts/code_category.html
+++ b/_layouts/code_category.html
@@ -93,9 +93,9 @@ layout: default
       <div class="col-wide">
         <!-- <h2 id="faqs">FAQ</h2> -->
         
-        Want your project listed or see a problem? Submit an issue
-        <a href="https://github.com/fortran-lang/fortran-lang.github.io/issues" target="_blank">
-          <i class="devicon-github-plain colored"></i> here</a>.
+        See
+	  <a href="https://github.com/fortran-lang/fortran-lang.github.io/blob/master/PACKAGES.md" target="_blank">
+      <i class="devicon-github-plain colored"></i> here</a> for how to get your project listed.
   
     </div>
   </section>

--- a/packages/index.html
+++ b/packages/index.html
@@ -116,9 +116,9 @@ description: A rich ecosystem of high-performance code
   <div class="container">
     <div class="col-wide">
       
-      Want your project listed or see a problem? Submit an issue
-        <a href="https://github.com/fortran-lang/fortran-lang.github.io/issues" target="_blank">
-          <i class="devicon-github-plain colored"></i> here</a>.
+      See
+	  <a href="https://github.com/fortran-lang/fortran-lang.github.io/blob/master/PACKAGES.md" target="_blank">
+          <i class="devicon-github-plain colored"></i> here</a> for how to get your project listed.
 
   </div>
 </section>

--- a/packages/search.html
+++ b/packages/search.html
@@ -32,9 +32,9 @@ title: Search
       <div class="col-wide">
         <!-- <h2 id="faqs">FAQ</h2> -->
         
-        Want your project listed or see a problem? Submit an issue
-        <a href="https://github.com/fortran-lang/fortran-lang.github.io/issues" target="_blank">
-          <i class="devicon-github-plain colored"></i> here</a>.
+      See
+	  <a href="https://github.com/fortran-lang/fortran-lang.github.io/blob/master/PACKAGES.md" target="_blank">
+          <i class="devicon-github-plain colored"></i> here</a> for how to get your project listed.
   
     </div>
   </section>


### PR DESCRIPTION
After #26 is merged, this will update the link at the bottom of 
the packages pages to point to PACKAGES.md which details the criteria and
process for getting a project listed in the index.