### PR TITLE
Github actions build & PR preview

### DIFF
--- a/.github/workflows/buildPRPreview.yml
+++ b/.github/workflows/buildPRPreview.yml
@@ -53,6 +53,7 @@ jobs:
         grep baseurl _config.yml|grep -v "#" |awk -F : '{print $2}' | xargs > base_url
         sed -i '/baseurl:/d' _config.yml
         echo "baseurl: $(cat base_url)/${{env.BUILD_DIR}}" >> _config.yml
+        echo "pull_request: ${{github.event.number}}" >> _config.yml
 
     # Run Jekyll build and copy output to PUBLISH_DIR
     - name: Build Jekyll Site

--- a/.github/workflows/buildPRPreview.yml
+++ b/.github/workflows/buildPRPreview.yml
@@ -1,0 +1,80 @@
+# Github action to build Jekyll site for a pull request preview
+#
+#  Built site is pushed to 'gh-pages' branch
+#   under directory pr/pr_id/
+#
+
+name: Jekyll PR Preview
+
+on:
+  pull_request:
+    branches: [ master ]
+
+env:
+  SRC_DIR: src
+  PUBLISH_DIR: gh-pages
+  SITE_URL: https://lkedward.github.io/gh-actions-test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+
+    # Checkout PR branch into SRC_DIR
+    - name: Checkout pr/${{github.event.number}}
+      uses: actions/checkout@v2
+      with:
+        path: ${{env.SRC_DIR}}
+    
+    # Checkout existing gh-pages branch into PUBLISH_DIR
+    - name: Checkout gh-pages
+      uses: actions/checkout@v2
+      with:
+        path: ${{env.PUBLISH_DIR}}
+        ref: 'gh-pages' 
+    
+    # Setup Jekyll in SRC_DIR
+    - name: Setup Jekyll
+      run: |
+        cd ${{env.SRC_DIR}}
+        sudo gem install bundler
+        bundle config path .bundle
+        bundle install
+    
+    # Sets Jekyll output directory using PR id
+    - name: Define output directory
+      run: echo "::set-env name=BUILD_DIR::pr/${{github.event.number}}"
+
+    # Appends PR-based output directory to Jekyll baseurl variable
+    - name: Update Jekyll site config
+      run: |
+        cd ${{env.SRC_DIR}}
+        grep baseurl _config.yml|grep -v "#" |awk -F : '{print $2}' | xargs > base_url
+        sed -i '/baseurl:/d' _config.yml
+        echo "baseurl: $(cat base_url)/${{env.BUILD_DIR}}" >> _config.yml
+
+    # Run Jekyll build and copy output to PUBLISH_DIR
+    - name: Build Jekyll Site
+      run: |
+        cd ${{env.SRC_DIR}}
+        bundle exec jekyll build -d _site/${BUILD_DIR}
+        cp -r _site/* ../${{env.PUBLISH_DIR}}/
+        touch ../${{env.PUBLISH_DIR}}/.nojekyll
+
+    # Commit and push changes to remote/gh-pages
+    - name: Commit and push to gh-pages
+      uses: EndBug/add-and-commit@master
+      with:
+        cwd: ${{env.PUBLISH_DIR}}
+        message: "Jekyll build, preview ${{env.BUILD_DIR}} (on:pull_request)"
+        ref: 'gh-pages'
+      env:  
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Write comment to PR with preview link
+    - name: Comment on PR with preview link
+      uses: thollander/actions-comment-pull-request@master
+      with:
+        message: "This PR has been built with Jekyll and can be previewed at: <${{env.SITE_URL}}/${{env.BUILD_DIR}}/>"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/buildPRPreview.yml
+++ b/.github/workflows/buildPRPreview.yml
@@ -13,7 +13,7 @@ on:
 env:
   SRC_DIR: src
   PUBLISH_DIR: gh-pages
-  SITE_URL: https://lkedward.github.io/gh-actions-test
+  SITE_URL: https://fortran-lang.org
 
 jobs:
   build:

--- a/.github/workflows/buildPRPreview.yml
+++ b/.github/workflows/buildPRPreview.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.body,'#no_preview') == false
     
     steps:
 

--- a/.github/workflows/buildSite.yml
+++ b/.github/workflows/buildSite.yml
@@ -1,0 +1,59 @@
+# Github action to build Jekyll site and commit to gh-pages branch
+#
+#  Built site is pushed to 'gh-pages' branch
+#
+
+name: Jekyll Build
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  SRC_DIR: src
+  PUBLISH_DIR: gh-pages
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+
+    # Checkout master branch into SRC_DIR
+    - name: Checkout master
+      uses: actions/checkout@v2
+      with:
+        path: ${{env.SRC_DIR}}
+
+    # Checkout existing gh-pages branch into PUBLISH_DIR
+    - name: Checkout gh-pages
+      uses: actions/checkout@v2
+      with:
+        path: ${{env.PUBLISH_DIR}}
+        ref: 'gh-pages'
+
+    # Setup Jekyll in SRC_DIR
+    - name: Setup Jekyll
+      run: |
+        cd ${{env.SRC_DIR}}
+        sudo gem install bundler
+        bundle config path .bundle
+        bundle install
+      
+    # Run Jekyll build and copy output to PUBLISH_DIR
+    - name: Build Jekyll Site
+      run: |
+        cd ${{env.SRC_DIR}}
+        bundle exec jekyll build 
+        cp -r _site/* ../${{env.PUBLISH_DIR}}/
+        touch ../${{env.PUBLISH_DIR}}/.nojekyll
+    
+    # Commit and push changes to remote/gh-pages
+    - name: Commit and push to gh-pages
+      uses: EndBug/add-and-commit@master
+      with:
+        cwd: ${{env.PUBLISH_DIR}}
+        message: "Jekyll build, commit ${{github.sha}} (on:push)"
+        ref: 'gh-pages'
+      env:  
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/closePR.yml
+++ b/.github/workflows/closePR.yml
@@ -1,0 +1,44 @@
+# Github action to cleanup a PR preview
+#
+
+name: PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [ closed ]
+
+env:
+  PUBLISH_DIR: gh-pages
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+
+    # Checkout existing gh-pages branch into PUBLISH_DIR
+    - name: Checkout gh-pages
+      uses: actions/checkout@v2
+      with:
+        path: ${{env.PUBLISH_DIR}}
+        ref: 'gh-pages' 
+    
+    # Sets Jekyll output directory using PR id
+    - name: Define output directory
+      run: echo "::set-env name=BUILD_DIR::pr/${{github.event.number}}"
+
+    # Cleanup preview files
+    - name: PR Cleanup
+      run: |
+        cd ${{env.PUBLISH_DIR}}
+        rm -rf ${{env.BUILD_DIR}}
+
+    # Commit and push changes to remote/gh-pages
+    - name: Commit and push to gh-pages
+      uses: EndBug/add-and-commit@master
+      with:
+        cwd: ${{env.PUBLISH_DIR}}
+        message: "Jekyll build, cleanup ${{env.BUILD_DIR}} (on:pr:close)"
+        ref: 'gh-pages'
+      env:  
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/closePR.yml
+++ b/.github/workflows/closePR.yml
@@ -1,11 +1,13 @@
 # Github action to cleanup a PR preview
 #
+#  Runs when a pull request comment contains '#delete_preview'
+#
 
 name: PR Preview Cleanup
 
 on:
-  pull_request:
-    types: [ closed ]
+  issue_comment:
+    types: [created]
 
 env:
   PUBLISH_DIR: gh-pages
@@ -13,6 +15,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body,'#delete_preview')
     
     steps:
 
@@ -21,24 +24,27 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{env.PUBLISH_DIR}}
-        ref: 'gh-pages' 
-    
-    # Sets Jekyll output directory using PR id
-    - name: Define output directory
-      run: echo "::set-env name=BUILD_DIR::pr/${{github.event.number}}"
+        ref: 'gh-pages'
 
     # Cleanup preview files
     - name: PR Cleanup
       run: |
         cd ${{env.PUBLISH_DIR}}
-        rm -rf ${{env.BUILD_DIR}}
+        rm -rf pr/${{github.event.issue.number}}
 
     # Commit and push changes to remote/gh-pages
     - name: Commit and push to gh-pages
       uses: EndBug/add-and-commit@master
       with:
         cwd: ${{env.PUBLISH_DIR}}
-        message: "Jekyll build, cleanup ${{env.BUILD_DIR}} (on:pr:close)"
+        message: "Jekyll build, cleanup pr/${{github.event.issue.number}}"
         ref: 'gh-pages'
       env:  
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    # Comment on pull request 
+    - name: Comment on pull request
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{github.event.issue.number}}
+        body: The preview build for this PR has now been deleted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ This allows reviewers to directly view the generated result of your PR.
 
 __Note: Subsequent pushes to your pull request branch will trigger new builds of the pull request preview.__
 
+__Note: to disable pull request preview builds, place the string '#no_preview' within the pull request description.__
+
 After a pull request has been merged and successfully rendered, the preview build can be deleted by commenting on
 the pull request with the following keyword: `#delete_preview`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to fortran-lang.github.io
+
+Fortran-lang.github.io is open-source and contributions are welcome!
+The Fortran-lang site uses the Ruby-based [Jekyll static site generator](https://jekyllrb.com/).
+To contribute you will therefore need to install Jekyll on your development computer.
+See [README.md](README.md) for how to setup Jekyll and build the site.
+
+This document details information for contributors and is broken into the following sections:
+
+1. [Contributor guide](#contributor-guide): information and guidelines for adding to and modifying existing site content
+
+2. [Developer information](#developer-information): detail on the structure of the site backend
+
+## Contributor guide
+
+### Workflow
+
+Contributions to the site are made by pull request to the github repository: <https://github.com/fortran-lang/fortran-lang.github.io/>.
+
+The workflow for doing so takes the following form:
+
+1. Create/update a personal fork of fortran-lang.github.io
+   - (See  [github help: syncing a fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) )
+
+2. Create a new branch in your fork
+   - The branch name should concisely describe your contribution, _e.g._ `fix-spelling-homepage`, `update-compiler-info`
+
+3. Perform your changes on the local branch
+
+4. Push your modified branch to your local fork
+   - _e.g._ `git push --set-upstream origin fix-spelling-homepage`
+
+5. Create a pull request in the fortran-lang/fortran-lang.github.io from your modified fork branch
+   - (See [github help: creating a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) )
+
+__Note: Before opening a pull request you must build your changes locally using Jekyll (see [README.md](README.md)) to verify that your changes build correctly and render as you expect.__
+
+Your pull request will be reviewed by other members of the community who may request changes.
+
+__Note: You can continue to push changes to your fork branch after you open a pull request  - the pull request will update accordingly__
+
+Once your pull request is approved, usually by at least two other community members, it will be merged into the fortran-lang.github.io master branch by the maintainers at which point it will be published to the fortran-lang.org site.
+
+
+### Pull request previews
+
+Once you open a pull request, a github action will execute and build your pull request branch to produce a public preview which will be available to view at `fortran-lang.org/pr/<pr_id>/` where `<pr_id>` is the numeric identifier of your pull request.
+
+This allows reviewers to directly view the generated result of your PR.
+
+__Note: Subsequent pushes to your pull request branch will trigger new builds of the pull request preview.__
+
+After a pull request has been merged and successfully rendered, the preview build can be deleted by commenting on
+the pull request with the following keyword: `#delete_preview`.
+
+### Internal site links
+
+Hyperlinks that point to other parts of the fortran-lang.org website should be prefixed with `{{ site.baseurl }}` - this is important for generating pull request previews (see [here](https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/) for an explanation).
+
+__Example:__ markdown link
+
+```
+[Fortran-lang news]({{site.baseurl}}/News)
+```
+
+__Example:__ html link
+
+```
+<a href="{{site.baseurl}}/Packages">Fortran packages</a>
+```
+
+
+## Developer information
+
+`Under development`

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="col-wide">
     {% for nav in site.data.nav %}
-      <a href="{{ nav.url }}">{{ nav.title }}</a>
+      <a href="{{ site.baseurl }}{{ nav.url }}">{{ nav.title }}</a>
       {% unless forloop.last %}
         &middot;
       {% endunless %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,10 +5,10 @@
 	    <div class="navbar-header">
 		<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#menu" aria-expanded="false">
 		    <span class="sr-only">Toggle navigation</span>
-		    <img src="/assets/img/icons/icon-menu.svg" alt="Toggle navigation" class="navbar-top-align">
+		    <img src="{{ site.baseurl }}/assets/img/icons/icon-menu.svg" alt="Toggle navigation" class="navbar-top-align">
 		</button>
-		<a href="/" class="navbar-brand">
-		    <img src="/assets/img/fortran_logo_256x256.png" id="navbar-logo" alt="Fortran">
+		<a href="{{ site.baseurl }}/" class="navbar-brand">
+		    <img src="{{ site.baseurl }}/assets/img/fortran_logo_256x256.png" id="navbar-logo" alt="Fortran">
 		</a>
 	    </div>
 	    <div class="collapse navbar-collapse navbar-top-align" id="menu">
@@ -19,12 +19,12 @@
 		    {% else %}
 		    <li>
 		    {% endif %}
-		    <a {% if nav.sections != null %}href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"{% else %}href="{{ nav.url }}"{% endif %}>{{ nav.title }}</a>
+		    <a {% if nav.sections != null %}href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"{% else %}href="{{ site.baseurl }}{{ nav.url }}"{% endif %}>{{ nav.title }}</a>
 		    {% if nav.sections != null %}
 			<ul class="dropdown-menu">
 			{% for section in nav.sections %}
 			    <li>
-				<a href="{{ section.url }}">{{ section.title }}</a>
+				<a href="{{ site.baseurl }}{{ section.url }}">{{ section.title }}</a>
 			    </li>
 			{% endfor %}
 			</ul>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,17 @@
 <header class="navbar">
+	{% if site.pull_request %}
+	<section class="front-section shaded purple"><div class="container">
+		
+		<h3>
+		<i data-feather="git-pull-request"></i>
+		<b>Site preview: </b>you are previewing unpublished changes for
+		
+		<a href="https://github.com/fortran-lang/fortran-lang.github.io/pull/{{site.pull_request}}" target="_blank">
+			<i class="devicon-github-plain colored"></i>
+			pull request {{site.pull_request}}</a>
+		</h3>
+	</div></section>
+	{% endif %} 
     <div class="container">
         <nav class="navbar">
 	    <div class="container-fluid">

--- a/_includes/news_sidebar.html
+++ b/_includes/news_sidebar.html
@@ -5,13 +5,13 @@
     {% assign posts_to_show = 5 %}
     {% for post in site.posts limit:posts_to_show %}
       <tr>
-        <td><a href="{{ post.url }}">{{ post.title }}</a>&nbsp;&nbsp; </td>
+        <td><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>&nbsp;&nbsp; </td>
         <td style="white-space: nowrap; text-align: right">{{ post.date | date:"%d %b %Y" }}</td>
       </tr>
       {% comment %} <dd></dd> {% endcomment %}
     {% endfor %}
     </table>
-    <p><a href="/news/archive">More…</a></p>
+    <p><a href="{{ site.baseurl }}/news/archive">More…</a></p>
 
   {% include what_is_fortran.html %}
 
@@ -20,6 +20,6 @@
 
   <h3>RSS</h3>
   <p>
-  RSS clients can follow the <a href="{{ site.news.feed }}">RSS feed</a>.
+  RSS clients can follow the <a href="{{ site.baseurl }}{{ site.news.feed }}">RSS feed</a>.
   </p>
 </div>

--- a/_includes/rss_feed.html
+++ b/_includes/rss_feed.html
@@ -1,3 +1,3 @@
 
 <h3>RSS feed</h3>
-<p>RSS clients can follow the <a href="{{ site.news.feed }}">RSS feed</a>.</p>
+<p>RSS clients can follow the <a href="{{site.baseurl}}{{ site.news.feed }}">RSS feed</a>.</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
   <div class="container">
     <div class="newsletter col-wide">
 
-      <a href="/news" > < Back to news</a>
+      <a href="{{ site.baseurl }}/news" > < Back to news</a>
 
       <h1>{{ page.title }}</h1>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -222,6 +222,11 @@ pre {
   background-color: #f4f4f4;
 }
 
+.front-section.shaded.purple {
+  background-color: #f2eef6;
+}
+
+
 .faqs dt {
   font-weight: 700;
 }

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
 
 <section class="masthead">
   <h1>High-performance parallel programming language</h1>
-  <p><a href="/learn/" class="btn">Get started</a></p>
+  <p><a href="{{ site.baseurl }}/learn/" class="btn">Get started</a></p>
 </section>
 
 <section class="front-section">
@@ -58,7 +58,7 @@ title: Home
         {% assign posts_to_show = 5 %}
         {% for post in site.posts limit:posts_to_show %}
           <tr>
-            <td><a href="{{ post.url }}">{{ post.title }}</a>&nbsp;&nbsp; </td>
+            <td><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>&nbsp;&nbsp; </td>
             <td style="white-space: nowrap; text-align: right">{{ post.date | date:"%d %b %Y" }}</td>
           </tr>
           {% comment %} <dd></dd> {% endcomment %}
@@ -66,7 +66,7 @@ title: Home
         </table>
         {% comment %} </dl> {% endcomment %}
 
-        <p><a href="/news/archive">More…</a></p>
+        <p><a href="{{ site.baseurl }}/news/archive">More…</a></p>
 
       </div>
     </div>

--- a/news/archive.html
+++ b/news/archive.html
@@ -9,14 +9,14 @@ title: News archive
   <div class="container">
     <div class="newsletter col-wide">
 
-      <h1><a href="/news">News</a> / Archive</h1>
+      <h1><a href="{{ site.baseurl }}/news">News</a> / Archive</h1>
 
       {% assign postsByYearMonth = site.categories.newsletter | group_by_exp:"post", "post.date | date: '%B %Y'"  %}
       {% for yearMonth in postsByYearMonth %}
         <h3>{{ yearMonth.name }}</h3>
           <ul>
             {% for post in yearMonth.items %}
-              <li><a href="{{ post.url }}">{{ post.title }}</a>
+              <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
               </li>
             {% endfor %}
           </ul>

--- a/news/index.html
+++ b/news/index.html
@@ -24,7 +24,7 @@ title: News
           {{ post.content }}
         {% else %}
           {{ post.excerpt }}
-          <a class="release-date" href="{{ post.url }}">
+          <a class="release-date" href="{{ site.baseurl }}{{ post.url }}">
             Read more > </a>
         {% endif %}
       </br>
@@ -42,7 +42,7 @@ title: News
       <div class="col-wide">
         
         See the 
-          <a href="/news/archive">news archive</a> for older posts  
+          <a href="{{ site.baseurl }}/news/archive">news archive</a> for older posts  
       </div>
     </div>
 


### PR DESCRIPTION
This PR aims to resolve #41.

The approach here is to use github actions to explicitly build the site on push as opposed to the automatic github Jekyll build used currently; this action builds the site using Jekyll on the master branch and pushes to the 'gh-pages' branch. (Repo settings will therefore need to be changed by admin here to point to 'gh-pages' branch).

Additional actions are added for pull requests which are built and pushed to the 'gh-pages' branch under the path 'pr/<pr_number>'; therefore pull requests can be previewed at fortran-lang.org/pr/46/ for example.

To enable the 'pr/<pr_number>' sub-path, the site source has been updated such that all internal site links and references are prepended with `{{site.baseurl}}`, see [here](https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/) for explanation.

I'm not an expert on github actions so if anyone has more experience and feedback then let me know!

This has been tested on a private repo, but I'm not sure if any extra steps are required for this organisation repo.