### PR TITLE
47 mailing list

### DIFF
--- a/_includes/mailing_list.html
+++ b/_includes/mailing_list.html
@@ -1,0 +1,3 @@
+<h3>Mailing list</h3>
+
+<p>Subscribe to our <a href="https://groups.io/g/fortran-lang">mailing list</a> to receive news in your email inbox.</p>

--- a/_includes/news_sidebar.html
+++ b/_includes/news_sidebar.html
@@ -15,11 +15,10 @@
 
   {% include what_is_fortran.html %}
 
-  <h3>Twitter</h3>
+  {% include mailing_list.html %}
+
   {% include twitter.html %}
 
-  <h3>RSS</h3>
-  <p>
-  RSS clients can follow the <a href="{{ site.news.feed }}">RSS feed</a>.
-  </p>
+  {% include rss_feed.html %}
+
 </div>

--- a/_includes/rss_feed.html
+++ b/_includes/rss_feed.html
@@ -1,0 +1,3 @@
+
+<h3>RSS feed</h3>
+<p>RSS clients can follow the <a href="{{ site.news.feed }}">RSS feed</a>.</p>

--- a/_includes/twitter.html
+++ b/_includes/twitter.html
@@ -1,3 +1,5 @@
+<h3>Twitter</h3>
+
 <a href="https://twitter.com/fortranlang" class="twitter-follow-button" data-show-count="true" data-size="large">@fortranlang</a>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 

--- a/index.html
+++ b/index.html
@@ -110,13 +110,19 @@ title: Home
     <div class="col-narrow">
       <h2 id="chat">Join us!</h2>
 
+      {% include mailing_list.html %}
+
       {% include twitter.html %}
 
+      {% include rss_feed.html %}
+
+      <h3>Open source</h3>
       <p>
       Contribute code, report bugs and request features at 
       <a href="https://github.com/fortran-lang">GitHub</a>.
       </p>
 
+      <h3>Stack Exchange</h3>
       <p>
         Ask about usage and configuration at <a href="https://stackoverflow.com/questions/tagged/fortran">Stack Exchange</a>.
       </p>


### PR DESCRIPTION
Adds the mailing list to the landing page and news sidebar.

It also makes a few minor imporovements such as add RSS feed to the news sidebar, and adds a heading to the Twitter component for consistency.

Fixes #47 