### PR TITLE
Make the scope of the mailinglist broader

### DIFF
--- a/_includes/mailing_list.html
+++ b/_includes/mailing_list.html
@@ -1,3 +1,6 @@
 <h3>Mailing list</h3>
 
-<p>Subscribe to our <a href="https://groups.io/g/fortran-lang">mailing list</a> to receive news in your email inbox.</p>
+<p>Subscribe to our <a href="https://groups.io/g/fortran-lang">mailing list</a>
+to discuss anything Fortran related, announce Fortran projects, have development
+discussions related to core fortran-lang.org projects (stdlib, fpm), and to get
+the latest news.</p>


### PR DESCRIPTION
If you have even better way to word this, go ahead and provide suggestions.

I want the mailing list to be a place where people can have a general discussion, announcements and other things. Not just to passively receive the latest news (Twitter is much better for that, and we already have a Twitter account).